### PR TITLE
import precip_water from calc for newer metpy

### DIFF
--- a/quickgrid.py
+++ b/quickgrid.py
@@ -6,7 +6,6 @@ import logging
 from tqdm import tqdm
 from tqdm import trange
 
-from metpy.future import precipitable_water
 import metpy.calc as mpcalc
 from metpy.units import units
 
@@ -96,7 +95,7 @@ def derived_products(ds_flight):
 
     for i in range(len(ds_flight["launch_time"])):
 
-        iwv[i] = precipitable_water(
+        iwv[i] = mpcalc.precipitable_water(
             ds_flight["pres"].isel(launch_time=i).values * units.mbar,
             ds_flight["dp"].isel(launch_time=i).values * units.degC,
         ).magnitude

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
         "numpy>=1.18.5",
         "xarray>=0.20.0",
         "netCDF4>=1.5.0",
-        "MetPy>=0.12.2",
+        "MetPy>=1.0",
         "cartopy>=0.18.0"
     ],
 )


### PR DESCRIPTION
Change the import of function `precipitable_water` from `__future__` to `calc` in `metpy`. This is needed for versions `metpy` v1.0  and above. This will therefore also require that the setup.py file is changed to ensure that when the package is created, only compatible versions of `metpy` are in the environment.

This PR should successfully solve issue #2.